### PR TITLE
floating gas price (#149)

### DIFF
--- a/contracts/Library/ExecutionLib.sol
+++ b/contracts/Library/ExecutionLib.sol
@@ -22,7 +22,7 @@ library ExecutionLib {
         internal returns (bool)
     {
         /// Should never actually reach this require check, but here in case.
-        require(self.gasPrice == tx.gasprice);
+        require(self.gasPrice <= tx.gasprice);
         /* solium-disable security/no-call-value */
         return self.toAddress.call.value(self.callValue).gas(self.callGas)(self.callData);
     }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -131,7 +131,7 @@ NOW DEPLOYING THE ETHEREUM ALARM CLOCK CONTRACTS...\n`)
         transactionRecorder: TransactionRecorder.address
       }
 
-      if (network) {
+      if (network && network !== "development") {
         const contractsFile = `${network}.json`
         const contractsInfoFile = `${network}.info`
         fs.writeFileSync(contractsFile, JSON.stringify(contracts))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
     "name": "ethereum-alarm-clock",
     "version": "0.9.3",
     "lockfileVersion": 1,
-    "requires": true,
     "dependencies": {
         "@digix/tempo": {
             "version": "0.2.0",
@@ -7984,6 +7983,12 @@
             "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
             "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
         },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
         "string-template": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -7999,12 +8004,6 @@
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
             }
-        },
-        "string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-            "dev": true
         },
         "stringstream": {
             "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "test": "truffle test",
         "coverage": "./node_modules/.bin/solidity-coverage",
         "lint": "./node_modules/eslint/bin/eslint.js .",
+        "lint-fix": "./node_modules/eslint/bin/eslint.js . --fix",
         "solium": "./node_modules/solium/bin/solium.js -d contracts --fix",
         "clean": "truffle networks --clean"
     },

--- a/test/dataHelpers.js
+++ b/test/dataHelpers.js
@@ -13,7 +13,7 @@ const parseAbortData = (executeTx) => {
     "AfterCallWindow", // 3
     "ReservedForClaimer", // 4
     "InsufficientGas", // 5
-    "MismatchGasPrice", // 6
+    "TooLowGasPrice", // 6
   ]
 
   const abortedLogs = executeTx.logs.filter(e => e.event === "Aborted")

--- a/test/transaction-request/execution.js
+++ b/test/transaction-request/execution.js
@@ -80,7 +80,7 @@ contract("Execution", async (accounts) => {
   })
 
   // / 2
-  it("cannot execute if transaction gasPrice != txnData.gasPrice", async () => {
+  it("cannot execute if transaction gasPrice < txnData.gasPrice", async () => {
     const requestData = await RequestData.from(txRequest)
 
     expect(requestData.schedule.windowStart).to.be.above(await config.web3.eth.getBlockNumber())
@@ -91,7 +91,7 @@ contract("Execution", async (accounts) => {
     const failedExecuteTx = await txRequest.execute({
       from: accounts[5],
       gas: 3000000,
-      gasPrice: config.web3.utils.toWei("88", "gwei"),
+      gasPrice: config.web3.utils.toWei("65", "gwei"),
     })
 
     expect(await txRecorder.wasCalled()).to.be.false
@@ -100,7 +100,7 @@ contract("Execution", async (accounts) => {
 
     expect(wasAborted(failedExecuteTx)).to.be.true
 
-    expect(parseAbortData(failedExecuteTx).find(reason => reason === "MismatchGasPrice")).to.exist
+    expect(parseAbortData(failedExecuteTx).find(reason => reason === "TooLowGasPrice")).to.exist
   })
 
   // 3


### PR DESCRIPTION
Changes the restriction that the executing TimeNode must send the same gasPrice as set. Now the requirement is that the set gasPrice is the *minimum* and the TimeNode is allowed to send more. It is not allowed to send less than the set gasPrice.